### PR TITLE
vendor: aosp: Build UPDATE-SuperSU as a selected prebuilt

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -60,15 +60,10 @@ PRODUCT_COPY_FILES +=  \
     vendor/aosp/prebuilt/common/media/PFFprec_600.emd:system/media/PFFprec_600.emd
 
 # SuperSU
-ifeq ($(BOARD_VENDOR),sony)
+PRODUCT_PACKAGES += \
+    UPDATE-SuperSU.zip
 PRODUCT_COPY_FILES += \
-    vendor/aosp/prebuilt/common/etc/UPDATE-SuperSU-2.52.zip:system/addon.d/UPDATE-SuperSU.zip \
     vendor/aosp/prebuilt/common/etc/init.d/99SuperSUDaemon:system/etc/init.d/99SuperSUDaemon
-else
-PRODUCT_COPY_FILES += \
-   vendor/aosp/prebuilt/common/etc/UPDATE-SuperSU.zip:system/addon.d/UPDATE-SuperSU.zip \
-   vendor/aosp/prebuilt/common/etc/init.d/99SuperSUDaemon:system/etc/init.d/99SuperSUDaemon
-endif
 
 # Substratum
 PRODUCT_COPY_FILES += \

--- a/prebuilt/common/Android.mk
+++ b/prebuilt/common/Android.mk
@@ -1,0 +1,16 @@
+LOCAL_PATH := $(call my-dir)
+
+# UPDATE-SuperSU
+include $(CLEAR_VARS)
+LOCAL_MODULE := UPDATE-SuperSU.zip
+
+ifeq ($(BOARD_VENDOR),sony)
+LOCAL_SRC_FILES := etc/UPDATE-SuperSU-2.52.zip
+else
+LOCAL_SRC_FILES := etc/UPDATE-SuperSU.zip
+endif
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_MODULE_PATH := $(TARGET_OUT)/addon.d
+include $(BUILD_PREBUILT)


### PR DESCRIPTION
- The board variables are not set upon common.mk call,
  hence the BOARD_VENDOR value is not available yet
- Declare a new 'UPDATE-SuperSU' prebuilt package,
  and select it with 'BOARD_VENDOR' upon build

Change-Id: I5e49ef17ad5ad0ab207a25e8f9265dbd6fa07559
